### PR TITLE
Configuración de postgres como base de datos

### DIFF
--- a/api/Gemfile
+++ b/api/Gemfile
@@ -5,8 +5,8 @@ ruby '2.5.1'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.1'
-# Use sqlite3 as the database for Active Record
-gem 'sqlite3'
+# Use postgresql as the database for Active Record
+gem 'pg', '>= 0.18', '< 2.0'
 # Use Puma as the app server
 gem 'puma', '~> 3.11'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder

--- a/api/Gemfile
+++ b/api/Gemfile
@@ -5,6 +5,8 @@ ruby '2.5.1'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.1'
+# Use sqlite3 as the database for Active Record
+gem 'sqlite3'
 # Use postgresql as the database for Active Record
 gem 'pg', '>= 0.18', '< 2.0'
 # Use Puma as the app server

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -89,6 +89,7 @@ GEM
     parallel (1.12.1)
     parser (2.5.1.2)
       ast (~> 2.4.0)
+    pg (1.1.0)
     powerpack (0.1.2)
     puma (3.12.0)
     rack (2.0.5)
@@ -168,7 +169,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.13)
     thor (0.20.0)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
@@ -188,6 +188,7 @@ DEPENDENCIES
   factory_bot_rails (~> 4.0)
   faker
   listen (>= 3.0.5, < 3.2)
+  pg (>= 0.18, < 2.0)
   puma (~> 3.11)
   rails (~> 5.2.1)
   rspec-rails (~> 3.5)
@@ -197,7 +198,6 @@ DEPENDENCIES
   shoulda-matchers (~> 3.1)
   spring
   spring-watcher-listen (~> 2.0.0)
-  sqlite3
   tzinfo-data
 
 RUBY VERSION

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -169,6 +169,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    sqlite3 (1.3.13)
     thor (0.20.0)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
@@ -198,6 +199,7 @@ DEPENDENCIES
   shoulda-matchers (~> 3.1)
   spring
   spring-watcher-listen (~> 2.0.0)
+  sqlite3
   tzinfo-data
 
 RUBY VERSION

--- a/api/config/database.yml
+++ b/api/config/database.yml
@@ -25,9 +25,10 @@ development:
 # Matias Manrique: I comment these lines so we remmember to confgure them
 # before running the integration tests and production deployment.
 # Delete this comment once this is correctly configured!
-#test:
-#  <<: *default
-#  database: db/test.sqlite3
+test:
+  <<: *default
+  adapter: sqlite3
+  database: db/test.sqlite3
 
 #production:
 #  <<: *default

--- a/api/config/database.yml
+++ b/api/config/database.yml
@@ -5,21 +5,30 @@
 #   gem 'sqlite3'
 #
 default: &default
-  adapter: sqlite3
+  adapter: postgresql
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
 
+# Configured for use of local database.
 development:
   <<: *default
-  database: db/development.sqlite3
+  host: localhost
+  port: 5432
+  database: 'wyehome-dev'
+  user: wyehome
+  password: wyehome
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
-test:
-  <<: *default
-  database: db/test.sqlite3
+#
+# Matias Manrique: I comment these lines so we remmember to confgure them
+# before running the integration tests and production deployment.
+# Delete this comment once this is correctly configured!
+#test:
+#  <<: *default
+#  database: db/test.sqlite3
 
-production:
-  <<: *default
-  database: db/production.sqlite3
+#production:
+#  <<: *default
+#  database: db/production.sqlite3

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -1,0 +1,18 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 0) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+end

--- a/dev-tools/README.md
+++ b/dev-tools/README.md
@@ -1,0 +1,6 @@
+## dev-tools
+
+Este directorio contiene scripts y herramientas que pueden facilitar la tarea de desarrollo. Por ejemplo puede tener scripts para levantar los servidores de rails y react, o setear ciertas configuraciones.
+
+ - [crear-pg-user.sh](https://github.com/wyeworks/pis-wyehome/blob/master/dev-tools/crear-pg-user.sh): Es un script que crea el usuario wyehome en una instancia local de postgres. Debería ser necesario ejecutarlo una única vez. Más detalles dentro del propio script.
+

--- a/dev-tools/README.md
+++ b/dev-tools/README.md
@@ -2,5 +2,5 @@
 
 Este directorio contiene scripts y herramientas que pueden facilitar la tarea de desarrollo. Por ejemplo puede tener scripts para levantar los servidores de rails y react, o setear ciertas configuraciones.
 
- - [crear-pg-user.sh](https://github.com/wyeworks/pis-wyehome/blob/master/dev-tools/crear-pg-user.sh): Es un script que crea el usuario wyehome en una instancia local de postgres. Debería ser necesario ejecutarlo una única vez. Más detalles dentro del propio script.
+ - [crear-pg-user.sh](https://github.com/wyeworks/pis-wyehome/blob/config-base-de-datos/dev-tools/crear-pg-user.sh): Es un script que crea el usuario wyehome en una instancia local de postgres. Debería ser necesario ejecutarlo una única vez. Más detalles dentro del propio script.
 

--- a/dev-tools/README.md
+++ b/dev-tools/README.md
@@ -2,5 +2,5 @@
 
 Este directorio contiene scripts y herramientas que pueden facilitar la tarea de desarrollo. Por ejemplo puede tener scripts para levantar los servidores de rails y react, o setear ciertas configuraciones.
 
- - [crear-pg-user.sh](https://github.com/wyeworks/pis-wyehome/blob/config-base-de-datos/dev-tools/crear-pg-user.sh): Es un script que crea el usuario wyehome en una instancia local de postgres. Debería ser necesario ejecutarlo una única vez. Más detalles dentro del propio script.
+ - [crear-pg-user.sh](crear-pg-user.sh): Es un script que crea el usuario wyehome en una instancia local de postgres. Debería ser necesario ejecutarlo una única vez. Más detalles dentro del propio script.
 

--- a/dev-tools/crear-pg-user.sh
+++ b/dev-tools/crear-pg-user.sh
@@ -1,0 +1,18 @@
+# This script should create a user (or 'role') in the postgres dbms. The user is
+# named wyehome with password wyehome.
+# This user is then used to create and update the development database. The idea
+# is to make it easier to setup the develpment environment.
+#
+# Requires Postgresql dbms and the psql client (probably installed alongside the
+# dbms).
+#
+# Usage should be something like this:
+#  cd pis-wyehome/api
+#  bundle install
+#  ../dev-tools/crear-pg-user.sh
+#  rails db:setup db:migrate
+#
+# Finally, we can see the tables of our database with:
+#  psql wyehome-dev -c \\l
+
+psql postgres -c "CREATE ROLE wyehome with createdb login password 'wyehome';"


### PR DESCRIPTION
Dado que la base de datos a utilizar será postgres, modifico la configuración de la base de desarrollo para que sea una instancia local de postgres.

Está configurado para crear una base llamada wyehome-dev, y conectarse con el usuario wyehome/wyehome.

Se supone que con Active Record no debería ser complicado usar bases distintas (por ejemplo sqlite para desarrollo y postgres para testing y producción), pero me parece mejor usar la misma en los tres ambientes ya que potencialmente evita problemas al pasar de un ambiente a otro.

La configuración de las bases de testing y producción se dejan para después dado que no tengo claro dónde van a estar hosteadas, cuál será el nombre y la autenticación, cuál debería ser el tamaño del pool de conexiones, etc.

Obiamente esto está abierto a discusión y el Pull Request puede ser rechazado.